### PR TITLE
Add Continuous Integration

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -4,7 +4,7 @@ jobs:
   sim:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/kkrizka/MCProd:pr-4
+      image: ghcr.io/kkrizka/mcprod:pr-4
     steps:
       -
         name: Checkout        

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         energy: [13, 100]
-        process: [B, BB, BBB, tt, t, tB, ttB, LL, LLB, vbf, H]
+        process: [B, BB, BBB, tt, t, tB, ttB, LL, LLB, vbf] #, H]
     steps:
       -
         name: Checkout        

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -17,9 +17,9 @@ jobs:
       -
         name: Generate GridPacks
         run: |
-          python makeGridPacks.py ${energy} B 1
+          python makeGridPacks.py ${{ matrix.energy }} B 1
           /opt/MG5aMC/3.3.1/bin/mg5_aMC < makeGridPacks.mg
-          tar -xzvf ${energy}TeV_B/run_01_gridpack.tar.gz
+          tar -xzvf ${{ matrix.energy }}TeV_B/run_01_gridpack.tar.gz
           cd madevent
           ./bin/compile
           ./bin/clean4grid

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         energy: [13, 100]
+        process: [B, BB, BBB, tt, t, tB, ttB, LL, LLB, vbf, H]
     steps:
       -
         name: Checkout        
@@ -17,10 +18,10 @@ jobs:
       -
         name: Generate GridPacks
         run: |
-          python makeGridPacks.py ${{ matrix.energy }} B 1
+          python makeGridPacks.py ${{ matrix.energy }} ${{ matrix.process }} 1
           /opt/MG5aMC/3.3.1/bin/mg5_aMC < makeGridPacks.mg
-          tar -xzvf ${{ matrix.energy }}TeV_B/run_01_gridpack.tar.gz
+          tar -xzvf ${{ matrix.energy }}TeV_${{ matrix.process }}/run_01_gridpack.tar.gz
           cd madevent
           ./bin/compile
-          ./bin/clean4grid
+          ./bin/clean4grid || true # Always fails due to `rm -f directory`
           ./bin/gridrun 1000 0 1

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -4,7 +4,7 @@ jobs:
   sim:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/kkrizka/MCProd:pr-4:
+      image: ghcr.io/kkrizka/MCProd:pr-4
     steps:
       -
         name: Checkout        

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -14,6 +14,10 @@ jobs:
       -
         name: Generate GridPacks
         run: |
-          ls
-          cd MCProd
-          testGridpacks.sh
+          ./makeGridPacks.py 13 B 1
+          /opt/MG5aMC/3.3.1/bin/mg5_aMC < run/makeGridPacks.mg
+          tar -xzvf 13TeV_B/run_01_gridpack.tar.gz
+          cd madevent
+          ./bin/compile
+          ./bin/clean4grid
+          ./bin/gridrun 1000 0 1

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,4 +13,7 @@ jobs:
           fetch-depth: 0
       -
         name: Generate GridPacks
-        run: testGridpacks.sh
+        run: |
+          ls
+          cd MCProd
+          testGridpacks.sh

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,16 @@
+name: Event Generation and Simulation
+on: push
+jobs:
+  sim:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/kkrizka/MCProd:pr-4:
+    steps:
+      -
+        name: Checkout        
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Generate GridPacks
+        run: testGridpacks.sh

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -18,7 +18,7 @@ jobs:
         name: Generate GridPacks
         run: |
           python makeGridPacks.py ${energy} B 1
-          /opt/MG5aMC/3.3.1/bin/mg5_aMC < run/makeGridPacks.mg
+          /opt/MG5aMC/3.3.1/bin/mg5_aMC < makeGridPacks.mg
           tar -xzvf ${energy}TeV_B/run_01_gridpack.tar.gz
           cd madevent
           ./bin/compile

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,7 +1,7 @@
 name: Event Generation and Simulation
 on: push
 jobs:
-  sim:
+  gen:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/kkrizka/mcprod:pr-4

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -5,6 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/kkrizka/mcprod:pr-4
+    strategy:
+      matrix:
+        energy: [13, 100]
     steps:
       -
         name: Checkout        
@@ -14,9 +17,9 @@ jobs:
       -
         name: Generate GridPacks
         run: |
-          ./makeGridPacks.py 13 B 1
+          python makeGridPacks.py ${energy} B 1
           /opt/MG5aMC/3.3.1/bin/mg5_aMC < run/makeGridPacks.mg
-          tar -xzvf 13TeV_B/run_01_gridpack.tar.gz
+          tar -xzvf ${energy}TeV_B/run_01_gridpack.tar.gz
           cd madevent
           ./bin/compile
           ./bin/clean4grid

--- a/makeGridPacks.py
+++ b/makeGridPacks.py
@@ -1,8 +1,3 @@
-from sys import argv
-E=int(argv[1])
-process=argv[2]
-if len(argv)>3: test=bool(int(argv[3]))
-
 definitions="""define p = g u c d s u~ c~ d~ s~ b b~
 define j = g u c d s u~ c~ d~ s~ b b~
 define l+ = e+ mu+ ta+
@@ -104,8 +99,24 @@ processes={
 
 import os
 import subprocess
-f=file('makeGridPacks.mg','w')
+
 if __name__=='__main__':
+    # Parse arguments
+    from sys import argv,exit
+
+    if len(argv)<3:
+        print('usage: {} E process [test]'.format(argv[0]))
+        sys.exit(1)
+
+    E=int(argv[1])
+    process=argv[2]
+    if len(argv)>3: test=bool(int(argv[3]))
+
+    # Currnt working directory for absolute path for resources
+    prodBase=os.path.dirname(os.path.realpath(__file__))
+
+    # Generate MG command
+    f=open('makeGridPacks.mg','w')
     f.write(definitions+'\n')
     command=processes[process]
     n=len(command[0].split('%')[0].split())
@@ -124,7 +135,7 @@ if __name__=='__main__':
     f.write('reweight=ON\n')
     #f.write('madspin=ON\n')  #causes crash
     f.write('done\n')
-    f.write(os.environ['prodBase']+'/Cards/param_card.dat\n')  
+    f.write(f'{prodBase}/Cards/param_card.dat\n')
     f.write('set gridpack = .true.\n')
     f.write('set ebeam1 = %i\n'%(1000*E/2))
     f.write('set ebeam2 = %i\n'%(1000*E/2))

--- a/makeGridPacks.sh
+++ b/makeGridPacks.sh
@@ -5,13 +5,6 @@ energies="13 100" #TeV
 test=1
 
 ##############################################
-#module load python/3.7.0
-#module load py-numpy/1.15.2-py3.7
-#module load py-six/1.11.0-py3.7
-
-#module load python/2.7.15
-#module load py-numpy/1.15.2-py2.7
-#module load py-six/1.11.0-py2.7
 
 if [[ ! -d gridpacks ]]; then mkdir gridpacks;
 else rm -rf gridpacks/*;

--- a/testGridpacks.sh
+++ b/testGridpacks.sh
@@ -1,7 +1,5 @@
 if [[ `basename $PWD` != "MCProd" ]]; then echo "Execute from MCProd dir"; exit; fi
 
-source $prodBase/setup.sh
-
 if [[ ! -d run ]]; then mkdir run;
 else rm -rf run/*;
 fi


### PR DESCRIPTION
Runs MadGraph event generation in gridpack mode for a matrix of energies and processes. No Pythia8 or Delphes running for now.

The `ghcr.io/kkrizka/mcprod:pr-4` Docker image is used.

A few fixes/improvements to `makeGridPacks.py`:
- All interactive code goes into the `__main__` protection.
- Help message when not enough arguments.
- Make Python 3 compatible.
- `prodBase` is taken to be the location of `makeGridPacks.py` instead of env variable.

Draft:
- [ ] Move Docker image to the Snowmass21-software group.
- [ ] Fix running the `H` process.
